### PR TITLE
Add start_server.sh for Linux/macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,12 @@ data/
 
 ## 🚀 Getting Started
 
-1. **Setup**: Open `index.html` in a modern web browser
-2. **Character Selection**: Choose your background (affects starting stats and story access)
-3. **Navigate**: Use clickable choices or keyboard shortcuts
-4. **Survive**: Balance tension, maintain morale, and make difficult choices
-5. **Multiple Playthroughs**: Discover different endings and unlock achievements
+1. **Start the Server**: Run `start_server.sh` on Linux/macOS or `start_server.bat` on Windows. The script tries Node.js first and falls back to Python.
+2. **Open the Game**: Your default browser should open automatically at `http://localhost:8080`. If not, open that address manually.
+3. **Character Selection**: Choose your background (affects starting stats and story access)
+4. **Navigate**: Use clickable choices or keyboard shortcuts
+5. **Survive**: Balance tension, maintain morale, and make difficult choices
+6. **Multiple Playthroughs**: Discover different endings and unlock achievements
 
 ## ⌨️ Controls
 

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# Simple launcher for Troubles Simulator
+# Tries Node.js first, then Python
+
+PORT=8080
+URL="http://localhost:$PORT"
+
+echo "Starting Troubles Simulator Server..."
+
+open_browser() {
+    if command -v xdg-open >/dev/null 2>&1; then
+        xdg-open "$URL" >/dev/null 2>&1 &
+    elif command -v open >/dev/null 2>&1; then
+        open "$URL" >/dev/null 2>&1 &
+    fi
+}
+
+start_and_wait() {
+    SERVER_PID=$1
+    echo "Server started at $URL"
+    open_browser
+    echo "Press Ctrl+C to stop the server."
+    trap 'echo "Stopping server..."; kill $SERVER_PID 2>/dev/null; exit 0' INT TERM
+    wait $SERVER_PID
+}
+
+if command -v node >/dev/null 2>&1; then
+    echo "Using Node.js server..."
+    node server.js &
+    start_and_wait $!
+    exit 0
+fi
+
+if command -v python >/dev/null 2>&1; then
+    echo "Using Python server..."
+    python start_server.py &
+    start_and_wait $!
+    exit 0
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    echo "Using Python3 server..."
+    python3 start_server.py &
+    start_and_wait $!
+    exit 0
+fi
+
+cat <<EOM
+ERROR: Neither Node.js nor Python found!
+Please install Node.js from https://nodejs.org/ or Python from https://python.org/
+EOM
+exit 1


### PR DESCRIPTION
## Summary
- add `start_server.sh` that starts Node or Python similar to batch script
- document new script in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685006a12038832fad80f5a617fe968a