### PR TITLE
Preload assets in troubles simulator init

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -18,7 +18,14 @@ class TroublesSimulator {
             
             // Load all game data
             const gameData = await this.dataLoader.loadAllData();
-            
+
+            // Preload assets like images and audio
+            try {
+                await this.dataLoader.preloadAssets(gameData.locations);
+            } catch (preloadError) {
+                console.error('Asset preloading failed:', preloadError);
+            }
+
             // Initialize game engine
             this.gameEngine = new GameEngine(gameData);
             


### PR DESCRIPTION
## Summary
- preload location assets before GameEngine initialization
- log errors when asset preloading fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685006983f48832fb2965ec10ad6c9ca