### PR TITLE
Populate game data JSON and refactor DataLoader

### DIFF
--- a/data/endings.json
+++ b/data/endings.json
@@ -1,1 +1,23 @@
-{}
+{
+  "ending_exile": {
+    "id": "ending_exile",
+    "type": "ending",
+    "endingType": "exile",
+    "text": "The weight of constant suspicion and fear becomes too much. You gather what few belongings you can carry and slip away in the night, leaving behind everything you once knew. The boat to Liverpool carries you toward an uncertain future, but away from the endless cycle of violence. You are alive, but forever marked by what you've witnessed.",
+    "choices": []
+  },
+  "ending_martyr": {
+    "id": "ending_martyr",
+    "type": "ending",
+    "endingType": "martyr",
+    "text": "Your final act of defiance echoes through the streets long after the gunfire fades. The murals painted in your memory tell a story of someone who stood for their beliefs, no matter the cost. In death, you become a symbol - though whether of hope or tragedy depends on who tells your story.",
+    "choices": []
+  },
+  "ending_survivor": {
+    "id": "ending_survivor",
+    "type": "ending",
+    "endingType": "survivor",
+    "text": "Against all odds, you've managed to navigate the treacherous currents of sectarian violence without losing yourself completely. The scars run deep - both visible and hidden - but you endure. Perhaps there's wisdom in survival, and hope that the next generation might find a different path.",
+    "choices": []
+  }
+}

--- a/data/items.json
+++ b/data/items.json
@@ -1,1 +1,85 @@
-{}
+{
+  "press_pass": {
+    "id": "press_pass",
+    "name": "Press Pass",
+    "description": "Official journalist credentials that may help in tense situations",
+    "type": "document",
+    "effects": {
+      "factionReputation": {
+        "british_army": 1
+      }
+    },
+    "usable": true,
+    "consumable": false
+  },
+  "notebook": {
+    "id": "notebook",
+    "name": "Reporter's Notebook",
+    "description": "A worn notebook filled with observations and contacts",
+    "type": "tool",
+    "effects": {},
+    "usable": false,
+    "consumable": false
+  },
+  "government_id": {
+    "id": "government_id",
+    "name": "Government ID",
+    "description": "Civil service identification card",
+    "type": "document",
+    "effects": {
+      "factionReputation": {
+        "british_army": 2
+      }
+    },
+    "usable": true,
+    "consumable": false
+  },
+  "coded_message": {
+    "id": "coded_message",
+    "name": "Coded Message",
+    "description": "An encrypted note with strategic information",
+    "type": "document",
+    "effects": {
+      "tension": -3,
+      "morale": 5
+    },
+    "usable": true,
+    "consumable": true
+  },
+  "fake_id": {
+    "id": "fake_id",
+    "name": "Fake ID",
+    "description": "Forged identification documents",
+    "type": "document",
+    "effects": {
+      "tension": -5
+    },
+    "usable": true,
+    "consumable": false,
+    "risk": "If discovered, increases all faction suspicion significantly"
+  },
+  "first_aid_kit": {
+    "id": "first_aid_kit",
+    "name": "First Aid Kit",
+    "description": "Basic medical supplies for treating injuries",
+    "type": "medical",
+    "effects": {
+      "morale": 10,
+      "ptsd": -5
+    },
+    "usable": true,
+    "consumable": true
+  },
+  "old_photograph": {
+    "id": "old_photograph",
+    "name": "Family Photograph",
+    "description": "A faded photo of happier times",
+    "type": "personal",
+    "effects": {
+      "morale": 5,
+      "tension": -2
+    },
+    "usable": true,
+    "consumable": false
+  }
+}

--- a/data/story-graph.json
+++ b/data/story-graph.json
@@ -54,27 +54,6 @@
       "type": "location_hub",
       "text": "You are at {currentLocation}. What do you want to do?",
       "choices": []
-    },
-    "ending_exile": {
-      "id": "ending_exile",
-      "type": "ending",
-      "endingType": "exile",
-      "text": "The weight of constant suspicion and fear becomes too much. You gather what few belongings you can carry and slip away in the night, leaving behind everything you once knew. The boat to Liverpool carries you toward an uncertain future, but away from the endless cycle of violence. You are alive, but forever marked by what you've witnessed.",
-      "choices": []
-    },
-    "ending_martyr": {
-      "id": "ending_martyr", 
-      "type": "ending",
-      "endingType": "martyr",
-      "text": "Your final act of defiance echoes through the streets long after the gunfire fades. The murals painted in your memory tell a story of someone who stood for their beliefs, no matter the cost. In death, you become a symbol - though whether of hope or tragedy depends on who tells your story.",
-      "choices": []
-    },
-    "ending_survivor": {
-      "id": "ending_survivor",
-      "type": "ending", 
-      "endingType": "survivor",
-      "text": "Against all odds, you've managed to navigate the treacherous currents of sectarian violence without losing yourself completely. The scars run deep - both visible and hidden - but you endure. Perhaps there's wisdom in survival, and hope that the next generation might find a different path.",
-      "choices": []
     }
   },
   "startNode": "intro"

--- a/js/modules/DataLoader.js
+++ b/js/modules/DataLoader.js
@@ -52,8 +52,8 @@ export class DataLoader {
                 this.loadJSON('locations.json'),
                 this.loadJSON('dialogue-trees.json'),
                 this.loadJSON('events.json'),
-                this.loadOptionalJSON('items.json'),
-                this.loadOptionalJSON('endings.json')
+                this.loadJSON('items.json'),
+                this.loadJSON('endings.json')
             ]);
 
             if (endings) {
@@ -70,7 +70,7 @@ export class DataLoader {
                 locations,
                 dialogueTrees,
                 events,
-                items: items || this.getDefaultItems()
+                items
             };
         } catch (error) {
             console.error('Failed to load game data:', error);
@@ -87,93 +87,6 @@ export class DataLoader {
         }
     }
 
-    getDefaultItems() {
-        return {
-            "press_pass": {
-                "id": "press_pass",
-                "name": "Press Pass",
-                "description": "Official journalist credentials that may help in tense situations",
-                "type": "document",
-                "effects": {
-                    "factionReputation": {
-                        "british_army": 1
-                    }
-                },
-                "usable": true,
-                "consumable": false
-            },
-            "notebook": {
-                "id": "notebook", 
-                "name": "Reporter's Notebook",
-                "description": "A worn notebook filled with observations and contacts",
-                "type": "tool",
-                "effects": {},
-                "usable": false,
-                "consumable": false
-            },
-            "government_id": {
-                "id": "government_id",
-                "name": "Government ID",
-                "description": "Civil service identification card",
-                "type": "document",
-                "effects": {
-                    "factionReputation": {
-                        "british_army": 2
-                    }
-                },
-                "usable": true,
-                "consumable": false
-            },
-            "coded_message": {
-                "id": "coded_message",
-                "name": "Coded Message",
-                "description": "An encrypted note with strategic information",
-                "type": "document",
-                "effects": {
-                    "tension": -3,
-                    "morale": 5
-                },
-                "usable": true,
-                "consumable": true
-            },
-            "fake_id": {
-                "id": "fake_id",
-                "name": "Fake ID",
-                "description": "Forged identification documents",
-                "type": "document",
-                "effects": {
-                    "tension": -5
-                },
-                "usable": true,
-                "consumable": false,
-                "risk": "If discovered, increases all faction suspicion significantly"
-            },
-            "first_aid_kit": {
-                "id": "first_aid_kit",
-                "name": "First Aid Kit",
-                "description": "Basic medical supplies for treating injuries",
-                "type": "medical",
-                "effects": {
-                    "morale": 10,
-                    "ptsd": -5
-                },
-                "usable": true,
-                "consumable": true
-            },
-            "old_photograph": {
-                "id": "old_photograph",
-                "name": "Family Photograph",
-                "description": "A faded photo of happier times",
-                "type": "personal",
-                "effects": {
-                    "morale": 5,
-                    "tension": -2
-                },
-                "usable": true,
-                "consumable": false
-            }
-        };
-    }
 
 
     clearCache() {


### PR DESCRIPTION
## Summary
- move item definitions into `data/items.json`
- move ending nodes into `data/endings.json`
- load new JSON files in `DataLoader` and remove `getDefaultItems`
- trim endings from `story-graph.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685090d01a38832fbaf3a280346afcdf