### PR TITLE
Add start screen with button

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,15 @@
         </div>
     </div>
 
+    <!-- Start Screen -->
+    <div id="start-screen" class="modal">
+        <div class="modal-content glass-panel p-8 max-w-md mx-auto text-center">
+            <h2 class="text-3xl font-bold mb-4">Troubles Simulator</h2>
+            <p class="mb-6">Navigate the moral complexities of the Northern Irish Troubles in this interactive narrative.</p>
+            <button id="start-game-btn" class="control-btn bg-green-600 hover:bg-green-700">Start Game</button>
+        </div>
+    </div>
+
     <!-- Settings Modal -->
     <div id="settings-modal" class="modal hidden">
         <div class="modal-content glass-panel p-6 max-w-md mx-auto mt-20">
@@ -191,7 +200,7 @@
     </div>
 
     <!-- Loading Screen -->
-    <div id="loading-screen" class="modal">
+    <div id="loading-screen" class="modal hidden">
         <div class="flex items-center justify-center h-screen">
             <div class="text-center">
                 <div class="loading-spinner mb-4"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -123,10 +123,19 @@ class TroublesSimulator {
 }
 
 // Initialize the game when DOM is loaded
-document.addEventListener('DOMContentLoaded', async () => {
+document.addEventListener('DOMContentLoaded', () => {
     const game = new TroublesSimulator();
     game.setupGlobalEventListeners();
-    await game.init();
+
+    const startBtn = document.getElementById('start-game-btn');
+    if (startBtn) {
+        startBtn.addEventListener('click', async () => {
+            document.getElementById('start-screen')?.classList.add('hidden');
+            await game.init();
+        });
+    } else {
+        game.init();
+    }
 });
 
 // Export for global access if needed


### PR DESCRIPTION
## Summary
- add a start screen overlay with a "Start Game" button
- wait for the start screen button to initialize the game
- hide the loading screen by default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68509843a524832f82dc3e90818b3295