### PR TITLE
Implement fog-of-war journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A comprehensive, immersive narrative game exploring the complex moral landscape 
 ### **Modern UI/UX**
 - **Glass Panel Design**: Beautiful, atmospheric interface with backdrop blur effects
 - **Animated Progress Bars**: Visual feedback for tension, morale, and PTSD levels
-- **Interactive Journal**: Persistent log of major choices, events, and NPC relationships
+ - **Interactive Journal**: Persistent log of major choices with a new "fog of war" effect that mirrors the character's mental state
 - **Responsive Design**: Optimized for desktop and mobile devices
 
 ### **Visual & Audio Atmosphere**

--- a/js/modules/GameEngine.js
+++ b/js/modules/GameEngine.js
@@ -573,15 +573,35 @@ export class GameEngine {
         return actions;
     }
 
-    addJournalEntry(text, type = 'general') {
+    addJournalEntry(objectiveText, type = 'general') {
+        const { ptsd = 0, tension = 0, morale = 100 } = this.currentPlayer?.stats || {};
+
+        let subjectiveText = objectiveText;
+
+        if (tension > 70) {
+            const words = objectiveText.replace(/[.!?]/g, '').split(/\s+/);
+            subjectiveText = words.map(w => `${w}.`).join(' ');
+            subjectiveText += ' Can\'t think.';
+        }
+
+        if (ptsd > 50) {
+            const blurPhrases = ["...it's all a blur.", "...the sounds won't stop."];
+            subjectiveText += ' ' + blurPhrases[Math.floor(Math.random() * blurPhrases.length)];
+        }
+
+        if (morale < 30) {
+            subjectiveText += " Another day, another tragedy. What's the point?";
+        }
+
         const entry = {
             id: Date.now() + Math.random(),
-            text,
+            text: subjectiveText,
+            objectiveText,
             type,
             timestamp: Date.now(),
             location: this.currentPlayer.location
         };
-        
+
         this.currentPlayer.journal.push(entry);
         this.uiRenderer.addJournalEntry(entry);
     }

--- a/js/modules/UIRenderer.js
+++ b/js/modules/UIRenderer.js
@@ -478,13 +478,17 @@ export class UIRenderer {
     addJournalEntry(entry) {
         const entryElement = document.createElement('div');
         entryElement.className = `journal-entry ${entry.type}`;
-        
+
         const timeString = new Date(entry.timestamp).toLocaleTimeString();
+        const subjectiveText = entry.text;
+
         entryElement.innerHTML = `
             <div class="text-xs text-gray-400 mb-1">${timeString} - ${entry.location}</div>
-            <div class="text-sm">${entry.text}</div>
+            <div class="text-sm">${subjectiveText}</div>
         `;
-        
+
+        entryElement.title = entry.objectiveText;
+
         this.elements.journalContent.appendChild(entryElement);
         this.scrollToBottom(this.elements.journalContent);
     }


### PR DESCRIPTION
## Summary
- add fog-of-war effect to the interactive journal
- support objective vs subjective text in journal entries
- show tooltip with objective entry text
- document journal feature in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68509c596ec8832f93a66ced85934ef8