### PR TITLE
Balance events and update validation

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -25,7 +25,7 @@
           "nextNode": "location_hub"
         },
         {
-          "text": "Flee the scene immediately", 
+          "text": "Flee the scene immediately",
           "effects": {
             "morale": -5,
             "ptsd": 5,
@@ -52,7 +52,7 @@
     },
     {
       "id": "sectarian_murder",
-      "type": "violence", 
+      "type": "violence",
       "location": "peace_line",
       "triggerConditions": {
         "minTension": 8,
@@ -144,7 +144,7 @@
     {
       "id": "informant_approach",
       "type": "moral",
-      "location": "local_pub", 
+      "location": "local_pub",
       "triggerConditions": {
         "minTension": 4
       },
@@ -267,6 +267,89 @@
             }
           },
           "consequence": "You leave them to it, trying not to think about the damage those papers will do. Guilt settles in as the shouts fade behind you.",
+          "nextNode": "location_hub"
+        }
+      ]
+    },
+    {
+      "id": "loyalist_pressure",
+      "type": "moral",
+      "location": "shankill_road",
+      "triggerConditions": {
+        "characterId": "protestant_civil"
+      },
+      "title": "Loyalist Demands",
+      "description": "At a back-room meeting, hardline loyalists ask you to use your civil service job to sabotage housing applications from Catholic neighborhoods.",
+      "choices": [
+        {
+          "text": "Quietly refuse and leave",
+          "effects": {
+            "morale": -5,
+            "tension": 10
+          },
+          "consequence": "You make excuses and get out as quickly as possible. Word spreads you might not be fully committed.",
+          "nextNode": "location_hub"
+        },
+        {
+          "text": "Agree to help them",
+          "effects": {
+            "morale": -20,
+            "tension": -5,
+            "factionReputation": {
+              "uda": 3
+            }
+          },
+          "consequence": "You agree, gaining protection from loyalists but losing your integrity.",
+          "nextNode": "location_hub"
+        },
+        {
+          "text": "Threaten to expose them",
+          "effects": {
+            "morale": 5,
+            "tension": 15,
+            "factionReputation": {
+              "uda": -5
+            }
+          },
+          "consequence": "They warn you that you're making powerful enemies. For now, they let you leave.",
+          "nextNode": "location_hub"
+        }
+      ]
+    },
+    {
+      "id": "threatening_call",
+      "type": "moral",
+      "location": "belfast_city_centre",
+      "triggerConditions": {
+        "characterId": "foreign_reporter"
+      },
+      "title": "Threatening Phone Call",
+      "description": "An anonymous caller warns you to stop digging into a recent bombing. They know where you are staying.",
+      "choices": [
+        {
+          "text": "Keep investigating despite the threat",
+          "effects": {
+            "morale": -5,
+            "tension": 10
+          },
+          "consequence": "Fear grips you but your resolve hardens. You double-check the locks on your door before heading out.",
+          "nextNode": "location_hub"
+        },
+        {
+          "text": "Contact your editor for advice",
+          "effects": {
+            "tension": -2
+          },
+          "consequence": "Your editor urges caution and promises to look into additional security. It's some comfort.",
+          "nextNode": "location_hub"
+        },
+        {
+          "text": "Lay low and avoid further reporting",
+          "effects": {
+            "morale": -10,
+            "tension": -5
+          },
+          "consequence": "You decide a story isn't worth your life. Another journalist might pick it up, but you feel defeated.",
           "nextNode": "location_hub"
         }
       ]

--- a/validate_narrative.js
+++ b/validate_narrative.js
@@ -1,13 +1,13 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 function loadJSON(relPath) {
   const fullPath = path.join(__dirname, relPath);
-  return JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+  return JSON.parse(fs.readFileSync(fullPath, "utf8"));
 }
 
 function gatherEvents(data) {
-  const categories = ['violentEvents', 'moralDilemmas', 'randomEncounters'];
+  const categories = ["violentEvents", "moralDilemmas", "randomEncounters"];
   const result = [];
   for (const cat of categories) {
     if (Array.isArray(data[cat])) {
@@ -17,14 +17,16 @@ function gatherEvents(data) {
   return result;
 }
 
-const eventsData = loadJSON('data/events.json');
-const charactersData = loadJSON('data/characters.json');
+const eventsData = loadJSON("data/events.json");
+const charactersData = loadJSON("data/characters.json");
 const events = gatherEvents(eventsData);
 const characters = Object.values(charactersData);
 
-console.log('Narrative Validation Report for Troubles Simulator v2');
-console.log('----------------------------------------------------\n');
-console.log(`Scanning ${events.length} events and ${characters.length} characters...\n`);
+console.log("Narrative Validation Report for Troubles Simulator v2");
+console.log("----------------------------------------------------\n");
+console.log(
+  `Scanning ${events.length} events and ${characters.length} characters...\n`,
+);
 
 const warnings = [];
 const errors = [];
@@ -33,15 +35,21 @@ const errors = [];
 for (const event of events) {
   const cond = event.triggerConditions || {};
   for (const [key, value] of Object.entries(cond)) {
-    if (key.startsWith('min')) {
+    if (key.startsWith("min")) {
       const root = key.slice(3);
-      const maxKey = 'max' + root;
+      const maxKey = "max" + root;
       if (cond.hasOwnProperty(maxKey)) {
         const minVal = value;
         const maxVal = cond[maxKey];
-        if (typeof minVal === 'number' && typeof maxVal === 'number' && minVal > maxVal) {
-          warnings.push(`Contradictory Condition in event '${event.id}': ` +
-            `condition '${key}' (${minVal}) is greater than '${maxKey}' (${maxVal}).`);
+        if (
+          typeof minVal === "number" &&
+          typeof maxVal === "number" &&
+          minVal > maxVal
+        ) {
+          warnings.push(
+            `Contradictory Condition in event '${event.id}': ` +
+              `condition '${key}' (${minVal}) is greater than '${maxKey}' (${maxVal}).`,
+          );
         }
       }
     }
@@ -51,27 +59,34 @@ for (const event of events) {
 // Collect all starting inventory items
 const startingItems = new Set();
 for (const char of characters) {
-  (char.startingInventory || []).forEach(it => startingItems.add(it));
+  (char.startingInventory || []).forEach((it) => startingItems.add(it));
 }
 
 // ----- Unreachable Events -----
-for (const char of characters) {
-  for (const event of events) {
-    const cond = event.triggerConditions || {};
-    if (cond.characterId && cond.characterId !== char.id) {
-      errors.push(`Unreachable Event for character '${char.id}': event '${event.id}' requires 'characterId': '${cond.characterId}'.`);
+for (const event of events) {
+  const cond = event.triggerConditions || {};
+  if (cond.characterId) {
+    const exists = characters.some((c) => c.id === cond.characterId);
+    if (!exists) {
+      errors.push(
+        `Unreachable Event '${event.id}': no character with id '${cond.characterId}'.`,
+      );
     }
   }
 }
 
 // ----- Missing Requirements -----
 for (const event of events) {
-  (event.choices || []).forEach(choice => {
+  (event.choices || []).forEach((choice) => {
     if (Array.isArray(choice.requirements) && choice.requirements.length > 0) {
-      const missing = choice.requirements.filter(req => !startingItems.has(req));
+      const missing = choice.requirements.filter(
+        (req) => !startingItems.has(req),
+      );
       if (missing.length > 0) {
-        errors.push(`Missing Requirement in event '${event.id}' choice '${choice.text}': ` +
-          `item(s) ${missing.join(', ')} not in any starting inventory.`);
+        errors.push(
+          `Missing Requirement in event '${event.id}' choice '${choice.text}': ` +
+            `item(s) ${missing.join(", ")} not in any starting inventory.`,
+        );
       }
     }
   });
@@ -79,7 +94,9 @@ for (const event of events) {
 
 const totalIssues = warnings.length + errors.length;
 
-warnings.forEach(msg => console.log(`[WARNING] ${msg}`));
-errors.forEach(msg => console.log(`[ERROR] ${msg}`));
+warnings.forEach((msg) => console.log(`[WARNING] ${msg}`));
+errors.forEach((msg) => console.log(`[ERROR] ${msg}`));
 
-console.log(`\n[INFO] Validation Complete. ${totalIssues} issue${totalIssues !== 1 ? 's' : ''} found.`);
+console.log(
+  `\n[INFO] Validation Complete. ${totalIssues} issue${totalIssues !== 1 ? "s" : ""} found.`,
+);


### PR DESCRIPTION
## Summary
- add unique story events for Protestant Civil Servant and Foreign Reporter
- modify validator to only flag events tied to nonexistent characters
- format updated files with Prettier

## Testing
- `npm test`
- `node validate_narrative.js`

------
https://chatgpt.com/codex/tasks/task_e_68509ebf1fc0832f9aa5c128aa02d084