### PR TITLE
Expand narrative depth and replayability

### DIFF
--- a/data/characters.json
+++ b/data/characters.json
@@ -16,10 +16,14 @@
       "british_army": -1,
       "civilians": 1
     },
-    "background": "Growing up on the Falls Road, you've learned to keep your head down and your mouth shut. The constant presence of soldiers and the whispered stories of neighbors who 'disappeared' have taught you that survival often means invisibility."
+    "background": "Raised amid nightly patrols and whispered warnings, you've memorized every alley and escape route on the Falls Road. Friends have vanished without explanation, teaching you early that trust can be fatal.",
+    "uniqueKnowledge": [
+      "knows_back_alleys",
+      "reads_graffitti_codes"
+    ]
   },
   "protestant_civil": {
-    "id": "protestant_civil", 
+    "id": "protestant_civil",
     "name": "Protestant Civil Servant",
     "description": "Protestant civil servant",
     "startLocation": "peace_line",
@@ -28,18 +32,24 @@
       "morale": 80,
       "ptsd": 0
     },
-    "startingInventory": ["government_id"],
+    "startingInventory": [
+      "government_id"
+    ],
     "factionReputation": {
       "ira": -2,
       "uda": 0,
       "british_army": 1,
       "civilians": 0
     },
-    "background": "Your job at the city council has given you a unique perspective on the bureaucracy of conflict. You've seen how political decisions play out in real lives, and you carry the weight of knowing how the system works - and fails."
+    "background": "Working in the city council means navigating mountains of paperwork and political favors. You've seen how housing lists and permits can become weapons, and you know which forms go missing.",
+    "uniqueKnowledge": [
+      "bureaucratic_shortcuts",
+      "access_to_records"
+    ]
   },
   "foreign_reporter": {
     "id": "foreign_reporter",
-    "name": "Foreign Reporter", 
+    "name": "Foreign Reporter",
     "description": "Foreign reporter",
     "startLocation": "belfast_city_centre",
     "startingStats": {
@@ -47,32 +57,46 @@
       "morale": 85,
       "ptsd": 0
     },
-    "startingInventory": ["press_pass", "notebook"],
+    "startingInventory": [
+      "press_pass",
+      "notebook"
+    ],
     "factionReputation": {
       "ira": 0,
-      "uda": 0, 
+      "uda": 0,
       "british_army": 0,
       "civilians": 0
     },
-    "background": "Armed with a press pass and an outsider's perspective, you've come to document the human cost of the conflict. Your neutrality is both your protection and your burden - everyone wants to tell you their story, but few trust your motives."
+    "background": "Armed with a press pass and an outsider's eye, you're determined to capture the human stories behind the headlines. Everyone wants to bend your ear, yet no one fully trusts you.",
+    "uniqueKnowledge": [
+      "press_contacts",
+      "interview_techniques"
+    ]
   },
   "ira_volunteer": {
     "id": "ira_volunteer",
     "name": "IRA Volunteer",
-    "description": "IRA volunteer lying low", 
+    "description": "IRA volunteer lying low",
     "startLocation": "countryside_safehouse",
     "startingStats": {
       "tension": 5,
       "morale": 70,
       "ptsd": 10
     },
-    "startingInventory": ["coded_message", "fake_id"],
+    "startingInventory": [
+      "coded_message",
+      "fake_id"
+    ],
     "factionReputation": {
       "ira": 2,
       "uda": -4,
       "british_army": -3,
       "civilians": -1
     },
-    "background": "The safe house feels less safe each day. Your face is known to the security forces, and every knock at the door could be your last. The cause that once burned bright in your heart now competes with the simple desire to see another sunrise."
+    "background": "You once shouted slogans with conviction, but months in hiding have worn you raw. Your network of safe houses is shrinking, and paranoia competes with devotion to the cause.",
+    "uniqueKnowledge": [
+      "code_phrases",
+      "safehouse_locations"
+    ]
   }
 }

--- a/data/dialogue-trees.json
+++ b/data/dialogue-trees.json
@@ -13,7 +13,7 @@
               "requirements": []
             },
             {
-              "text": "Any advice for staying safe?", 
+              "text": "Any advice for staying safe?",
               "nextNode": "safety_advice",
               "requirements": []
             },
@@ -21,6 +21,28 @@
               "text": "I'll be careful. Thanks.",
               "nextNode": "polite_exit",
               "requirements": []
+            },
+            {
+              "text": "Show a family photo",
+              "nextNode": "shared_mourning",
+              "requirements": [
+                {
+                  "type": "inventory",
+                  "key": "old_photograph",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "text": "Speak in local slang",
+              "nextNode": "trusted_local",
+              "requirements": [
+                {
+                  "type": "character",
+                  "key": "id",
+                  "value": "catholic_teen"
+                }
+              ]
             }
           ]
         },
@@ -29,7 +51,7 @@
           "choices": [
             {
               "text": "Do you know who was responsible?",
-              "nextNode": "blame_game", 
+              "nextNode": "blame_game",
               "requirements": []
             },
             {
@@ -53,13 +75,33 @@
             },
             {
               "text": "Thanks for the warning.",
-              "nextNode": "grateful_exit", 
+              "nextNode": "grateful_exit",
               "requirements": []
             }
           ],
           "effects": {
             "tension": 1
           }
+        },
+        "shared_mourning": {
+          "text": "The resident studies the photo and nods. 'We all have someone we've lost,' they say quietly.",
+          "choices": [
+            {
+              "text": "Thanks for understanding.",
+              "nextNode": "polite_exit",
+              "requirements": []
+            }
+          ]
+        },
+        "trusted_local": {
+          "text": "Hearing the slang, they relax a little. 'Alright, you're one of us then.'",
+          "choices": [
+            {
+              "text": "Any news from the street?",
+              "nextNode": "recent_events",
+              "requirements": []
+            }
+          ]
         }
       }
     },
@@ -84,6 +126,17 @@
               "text": "The situation is complicated.",
               "nextNode": "diplomatic_response",
               "requirements": []
+            },
+            {
+              "text": "Use a coded phrase",
+              "nextNode": "coded_exchange",
+              "requirements": [
+                {
+                  "type": "inventory",
+                  "key": "coded_message",
+                  "value": true
+                }
+              ]
             }
           ]
         },
@@ -112,6 +165,21 @@
             },
             "tension": 2
           }
+        },
+        "coded_exchange": {
+          "text": "Their eyes widen in recognition. 'You know more than you let on,' they whisper.",
+          "choices": [
+            {
+              "text": "I want in.",
+              "nextNode": "recruitment_pitch",
+              "requirements": []
+            },
+            {
+              "text": "Just passing a message.",
+              "nextNode": "neutral_response",
+              "requirements": []
+            }
+          ]
         }
       }
     },
@@ -136,6 +204,28 @@
               "text": "Am I in some kind of trouble?",
               "nextNode": "nervous_response",
               "requirements": []
+            },
+            {
+              "text": "I'm press. Here's my pass.",
+              "nextNode": "press_priority",
+              "requirements": [
+                {
+                  "type": "inventory",
+                  "key": "press_pass",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "text": "Show government credentials",
+              "nextNode": "civil_service_pass",
+              "requirements": [
+                {
+                  "type": "inventory",
+                  "key": "government_id",
+                  "value": true
+                }
+              ]
             }
           ]
         },
@@ -164,11 +254,31 @@
               "british_army": -1
             }
           }
+        },
+        "press_priority": {
+          "text": "The soldier glances at your pass and motions you through with barely a look.",
+          "choices": [
+            {
+              "text": "Move along quickly",
+              "nextNode": "polite_exit",
+              "requirements": []
+            }
+          ]
+        },
+        "civil_service_pass": {
+          "text": "'Sorry, sir/madam,' he says, suddenly respectful. 'Didn't realize.'",
+          "choices": [
+            {
+              "text": "Ask about patrol plans",
+              "nextNode": "probe_information",
+              "requirements": []
+            }
+          ]
         }
       }
     },
     "uda_member": {
-      "name": "UDA Member", 
+      "name": "UDA Member",
       "description": "A hard-faced individual with tattoos visible under rolled sleeves",
       "dialogueTree": {
         "initial": {
@@ -181,7 +291,7 @@
             },
             {
               "text": "I belong here as much as anyone.",
-              "nextNode": "defiant_response", 
+              "nextNode": "defiant_response",
               "requirements": []
             },
             {
@@ -235,6 +345,17 @@
               "text": "Heard anything interesting lately?",
               "nextNode": "fishing_for_info",
               "requirements": []
+            },
+            {
+              "text": "Show an old photograph",
+              "nextNode": "nostalgic_talk",
+              "requirements": [
+                {
+                  "type": "inventory",
+                  "key": "old_photograph",
+                  "value": true
+                }
+              ]
             }
           ]
         },
@@ -295,6 +416,16 @@
             {
               "text": "Fair enough.",
               "nextNode": "polite_exit",
+              "requirements": []
+            }
+          ]
+        },
+        "nostalgic_talk": {
+          "text": "The barman squints at the picture and sighs. 'Those were better days.'",
+          "choices": [
+            {
+              "text": "Share a quiet toast",
+              "nextNode": "simple_order",
               "requirements": []
             }
           ]

--- a/data/endings.json
+++ b/data/endings.json
@@ -3,21 +3,21 @@
     "id": "ending_exile",
     "type": "ending",
     "endingType": "exile",
-    "text": "The weight of constant suspicion and fear becomes too much. You gather what few belongings you can carry and slip away in the night, leaving behind everything you once knew. The boat to Liverpool carries you toward an uncertain future, but away from the endless cycle of violence. You are alive, but forever marked by what you've witnessed.",
+    "text": "Unable to bear the constant suspicion, you pack what little you own and vanish across the sea. The shoreline fades behind you, taking with it friends, foes, and a piece of your soul. In exile you survive, but every news report drags you back to the streets you fled.",
     "choices": []
   },
   "ending_martyr": {
     "id": "ending_martyr",
     "type": "ending",
     "endingType": "martyr",
-    "text": "Your final act of defiance echoes through the streets long after the gunfire fades. The murals painted in your memory tell a story of someone who stood for their beliefs, no matter the cost. In death, you become a symbol - though whether of hope or tragedy depends on who tells your story.",
+    "text": "Your last stand ignites whispers and songs long after the shooting stops. To some you're a hero, to others a cautionary tale, but no one forgets the conviction that carried you to the end.",
     "choices": []
   },
   "ending_survivor": {
     "id": "ending_survivor",
     "type": "ending",
     "endingType": "survivor",
-    "text": "Against all odds, you've managed to navigate the treacherous currents of sectarian violence without losing yourself completely. The scars run deep - both visible and hidden - but you endure. Perhaps there's wisdom in survival, and hope that the next generation might find a different path.",
+    "text": "Through compromise, cunning, or sheer luck, you outlast the bloodshed. The scars remain, yet so does the faint hope that tomorrow will see fewer coffins and more conversations.",
     "choices": []
   }
 }

--- a/data/events.json
+++ b/data/events.json
@@ -6,10 +6,12 @@
       "location": "belfast_city_centre",
       "triggerConditions": {
         "minTension": 5,
-        "excludeIfTriggered": ["bombing_aftermath"]
+        "excludeIfTriggered": [
+          "bombing_aftermath"
+        ]
       },
       "title": "Bomb Explosion",
-      "description": "A deafening explosion rocks the street ahead of you. Through the smoke and screaming, you see bodies scattered among the debris. Glass and concrete rain down as car alarms wail. The acrid smell of explosives mixes with something worse.",
+      "description": "A thunderous blast flips cars and shatters storefronts. Smoke stings your eyes and the street echoes with panicked screams.",
       "choices": [
         {
           "text": "Rush to help the wounded",
@@ -39,7 +41,10 @@
         },
         {
           "text": "Take photographs of the scene",
-          "requirements": ["notebook", "press_pass"],
+          "requirements": [
+            "notebook",
+            "press_pass"
+          ],
           "effects": {
             "morale": -8,
             "ptsd": 10,
@@ -59,7 +64,7 @@
         "maxMorale": 50
       },
       "title": "Sectarian Killing",
-      "description": "You witness a man being dragged from his car by masked figures. His pleas for mercy are cut short by gunshots. His crime was being on the wrong side of the peace wall at the wrong time. The killers melt away into the night, leaving only silence and blood.",
+      "description": "Masked men drag a driver from his car, accusations flying before gunshots end his pleas. Blood pools on the tarmac as silence returns.",
       "choices": [
         {
           "text": "Try to identify the killers",
@@ -96,7 +101,7 @@
         "minTension": 6
       },
       "title": "Police Brutality",
-      "description": "RUC officers have cornered a teenager against a wall. Their batons rise and fall with sickening thuds. The boy's cries echo off the brick walls as blood streams down his face. 'This is what happens to fenian scum,' one officer growls.",
+      "description": "RUC batons rise and fall on a cornered teenager. Each dull crack reverberates down the alley while onlookers avert their gaze.",
       "choices": [
         {
           "text": "Intervene directly",
@@ -135,6 +140,67 @@
             "tension": 3
           },
           "consequence": "You hurry past, trying to block out the sounds. Sometimes the price of involvement is too high to pay. The guilt follows you home.",
+          "nextNode": "location_hub"
+        }
+      ]
+    },
+    {
+      "id": "drive_by_attack",
+      "type": "violence",
+      "location": "shankill_road",
+      "triggerConditions": {
+        "minTension": 7
+      },
+      "title": "Drive-by Shooting",
+      "description": "A car screeches past and automatic fire erupts, leaving shattered windows and bodies in its wake.",
+      "choices": [
+        {
+          "text": "Take cover and stay silent",
+          "effects": {
+            "tension": 5,
+            "ptsd": 10
+          },
+          "consequence": "You dive behind a wall until the gunfire fades.",
+          "nextNode": "location_hub"
+        },
+        {
+          "text": "Try to note the license plate",
+          "effects": {
+            "tension": 8,
+            "ptsd": 12
+          },
+          "consequence": "You catch a glimpse of the plate, knowledge that could make you a target.",
+          "nextNode": "location_hub"
+        }
+      ]
+    },
+    {
+      "id": "night_raid",
+      "type": "violence",
+      "location": "countryside_safehouse",
+      "triggerConditions": {
+        "characterId": "ira_volunteer",
+        "minTension": 6
+      },
+      "title": "Night Raid",
+      "description": "Spotlights sweep the farmhouse as troops surround the building, shouting orders over bullhorns.",
+      "choices": [
+        {
+          "text": "Slip out the back",
+          "effects": {
+            "tension": 10,
+            "morale": -5
+          },
+          "consequence": "You escape into the fields but leave comrades behind.",
+          "nextNode": "location_hub"
+        },
+        {
+          "text": "Barricade the door",
+          "effects": {
+            "tension": 15,
+            "ptsd": 10
+          },
+          "consequence": "You brace for a siege as bootsteps pound on the porch.",
           "nextNode": "location_hub"
         }
       ]
@@ -353,13 +419,76 @@
           "nextNode": "location_hub"
         }
       ]
+    },
+    {
+      "id": "family_package",
+      "type": "moral",
+      "location": "falls_road",
+      "triggerConditions": {
+        "characterId": "catholic_teen"
+      },
+      "title": "A Relative's Request",
+      "description": "An older cousin hands you a sealed box, insisting it be delivered across town without questions.",
+      "choices": [
+        {
+          "text": "Agree to deliver it",
+          "effects": {
+            "tension": 5,
+            "morale": -5
+          },
+          "consequence": "The weight of the unknown package grows heavier with every step.",
+          "nextNode": "location_hub"
+        },
+        {
+          "text": "Refuse and demand answers",
+          "effects": {
+            "tension": 8,
+            "morale": 5
+          },
+          "consequence": "Your cousin's eyes narrow with hurt and suspicion.",
+          "nextNode": "location_hub"
+        }
+      ]
+    },
+    {
+      "id": "press_ethics",
+      "type": "moral",
+      "location": "belfast_city_centre",
+      "triggerConditions": {
+        "characterId": "foreign_reporter"
+      },
+      "title": "Graphic Photo Opportunity",
+      "description": "A bystander urges you to photograph a dying victim for proof. The scene is horrific.",
+      "choices": [
+        {
+          "text": "Take the photo",
+          "effects": {
+            "ptsd": 10,
+            "morale": -5
+          },
+          "consequence": "The image will haunt you, but it might sway public opinion.",
+          "nextNode": "location_hub"
+        },
+        {
+          "text": "Lower the camera",
+          "effects": {
+            "morale": 5,
+            "tension": -2
+          },
+          "consequence": "You choose compassion over evidence, leaving the story incomplete.",
+          "nextNode": "location_hub"
+        }
+      ]
     }
   ],
   "randomEncounters": [
     {
       "id": "checkpoint_search",
       "type": "encounter",
-      "locations": ["military_checkpoint", "border_crossing"],
+      "locations": [
+        "military_checkpoint",
+        "border_crossing"
+      ],
       "triggerChance": 0.6,
       "title": "Random Search",
       "description": "The soldiers motion you over for a more thorough inspection. They empty your pockets and question your purpose in the area.",
@@ -384,6 +513,64 @@
             }
           },
           "consequence": "Your attitude is noted as 'uncooperative.' The search becomes more thorough and humiliating, but they find nothing.",
+          "nextNode": "location_hub"
+        }
+      ]
+    },
+    {
+      "id": "lost_child",
+      "type": "encounter",
+      "locations": [
+        "falls_road",
+        "belfast_city_centre"
+      ],
+      "triggerChance": 0.4,
+      "title": "Lost Child",
+      "description": "A small child tugs your sleeve, sobbing that they can't find their parents amid the chaos.",
+      "choices": [
+        {
+          "text": "Help search for the parents",
+          "effects": {
+            "morale": 5
+          },
+          "consequence": "After a tense search you reunite the family, earning grateful smiles.",
+          "nextNode": "location_hub"
+        },
+        {
+          "text": "Point them toward a soldier",
+          "effects": {
+            "tension": -2
+          },
+          "consequence": "You send the child toward the checkpoint, uncertain if that's truly safe.",
+          "nextNode": "location_hub"
+        }
+      ]
+    },
+    {
+      "id": "secret_meeting",
+      "type": "encounter",
+      "locations": [
+        "local_pub"
+      ],
+      "triggerChance": 0.3,
+      "title": "Whispered Invitation",
+      "description": "A stranger slips you a note requesting a late-night meeting in an alley.",
+      "choices": [
+        {
+          "text": "Attend the meeting",
+          "effects": {
+            "tension": 5
+          },
+          "consequence": "The rendezvous reveals new rumors swirling through the city.",
+          "nextNode": "location_hub"
+        },
+        {
+          "text": "Burn the note",
+          "effects": {
+            "morale": 2,
+            "tension": -1
+          },
+          "consequence": "You decide it's best not to get involved with shadowy figures.",
           "nextNode": "location_hub"
         }
       ]

--- a/data/items.json
+++ b/data/items.json
@@ -2,7 +2,7 @@
   "press_pass": {
     "id": "press_pass",
     "name": "Press Pass",
-    "description": "Official journalist credentials that may help in tense situations",
+    "description": "A laminated badge stamped with foreign press credentials. Flashing it can open doors\u2014or paint a target on your back.",
     "type": "document",
     "effects": {
       "factionReputation": {
@@ -15,7 +15,7 @@
   "notebook": {
     "id": "notebook",
     "name": "Reporter's Notebook",
-    "description": "A worn notebook filled with observations and contacts",
+    "description": "Pages dog-eared and ink-stained, filled with hurried interviews and half-legible shorthand.",
     "type": "tool",
     "effects": {},
     "usable": false,
@@ -24,7 +24,7 @@
   "government_id": {
     "id": "government_id",
     "name": "Government ID",
-    "description": "Civil service identification card",
+    "description": "An official card bearing the Crown's crest. It grants access but also binds you to bureaucracy.",
     "type": "document",
     "effects": {
       "factionReputation": {
@@ -37,7 +37,7 @@
   "coded_message": {
     "id": "coded_message",
     "name": "Coded Message",
-    "description": "An encrypted note with strategic information",
+    "description": "A scrap of paper covered in numbers and phrases only a trained eye can decipher.",
     "type": "document",
     "effects": {
       "tension": -3,
@@ -49,7 +49,7 @@
   "fake_id": {
     "id": "fake_id",
     "name": "Fake ID",
-    "description": "Forged identification documents",
+    "description": "An expertly forged document, perfect until someone looks too closely.",
     "type": "document",
     "effects": {
       "tension": -5
@@ -61,7 +61,7 @@
   "first_aid_kit": {
     "id": "first_aid_kit",
     "name": "First Aid Kit",
-    "description": "Basic medical supplies for treating injuries",
+    "description": "A small pouch of bandages and antiseptic\u2014life-saving when violence erupts.",
     "type": "medical",
     "effects": {
       "morale": 10,
@@ -73,7 +73,7 @@
   "old_photograph": {
     "id": "old_photograph",
     "name": "Family Photograph",
-    "description": "A faded photo of happier times",
+    "description": "A creased snapshot of smiling faces, a reminder of what peace once looked like.",
     "type": "personal",
     "effects": {
       "morale": 5,

--- a/data/locations.json
+++ b/data/locations.json
@@ -2,13 +2,21 @@
   "falls_road": {
     "id": "falls_road",
     "name": "Falls Road",
-    "description": "Tense streets filled with murals and frequent patrols. The air is thick with unspoken loyalties and the constant threat of violence.",
+    "description": "The claustrophobic streets smell of damp brick and spray paint. Murals glare down as patrol boots echo through the night, each step questioning your loyalty.",
     "backgroundImage": "",
     "originalBackgroundImage": "assets/images/falls-road.jpg",
     "ambientSound": "",
-    "originalAmbientSound": "assets/audio/urban-tension.mp3", 
-    "connections": ["peace_line", "local_pub", "belfast_city_centre"],
-    "npcs": ["local_resident", "ira_sympathizer", "british_patrol"],
+    "originalAmbientSound": "assets/audio/urban-tension.mp3",
+    "connections": [
+      "peace_line",
+      "local_pub",
+      "belfast_city_centre"
+    ],
+    "npcs": [
+      "local_resident",
+      "ira_sympathizer",
+      "british_patrol"
+    ],
     "searchable": true,
     "atmosphere": {
       "lighting": "harsh streetlights",
@@ -24,14 +32,21 @@
   },
   "peace_line": {
     "id": "peace_line",
-    "name": "Peace Line", 
-    "description": "Towering concrete and steel walls separating communities, watched over by troops in fortified posts. The barriers stretch as far as the eye can see.",
+    "name": "Peace Line",
+    "description": "Concrete and steel slice the community in two, razor wire and floodlights turning every passerby into a suspect.",
     "backgroundImage": "",
     "originalBackgroundImage": "assets/images/peace-wall.jpg",
     "ambientSound": "",
     "originalAmbientSound": "assets/audio/wind-barriers.mp3",
-    "connections": ["falls_road", "shankill_road"],
-    "npcs": ["british_soldier", "checkpoint_guard", "local_resident"],
+    "connections": [
+      "falls_road",
+      "shankill_road"
+    ],
+    "npcs": [
+      "british_soldier",
+      "checkpoint_guard",
+      "local_resident"
+    ],
     "searchable": false,
     "atmosphere": {
       "lighting": "harsh spotlights",
@@ -46,15 +61,22 @@
     ]
   },
   "shankill_road": {
-    "id": "shankill_road", 
+    "id": "shankill_road",
     "name": "Shankill Road",
-    "description": "A fiercely loyalist area where Union Jacks fly from many windows and murals depict paramilitary figures in stark detail.",
+    "description": "Frying grease and cigarette smoke mingle as loyalist songs drift from doorways. Union Jacks flap like warnings, and murals of masked men stake their claim.",
     "backgroundImage": "",
-    "originalBackgroundImage": "assets/images/shankill-road.jpg", 
+    "originalBackgroundImage": "assets/images/shankill-road.jpg",
     "ambientSound": "",
     "originalAmbientSound": "assets/audio/loyalist-area.mp3",
-    "connections": ["peace_line", "local_pub"],
-    "npcs": ["uda_member", "loyalist_resident", "paramilitiry_volunteer"],
+    "connections": [
+      "peace_line",
+      "local_pub"
+    ],
+    "npcs": [
+      "uda_member",
+      "loyalist_resident",
+      "paramilitiry_volunteer"
+    ],
     "searchable": true,
     "atmosphere": {
       "lighting": "red, white, and blue bunting",
@@ -71,13 +93,20 @@
   "countryside_safehouse": {
     "id": "countryside_safehouse",
     "name": "Countryside Safehouse",
-    "description": "A quiet farmhouse rumored to be a hideout. The silence of the fields feels heavier than the city's noise, broken only by distant helicopters.",
+    "description": "A lonely farmhouse hides behind hedgerows, the damp earth heavy with the thrum of distant helicopters. Every creak could be an informer at the door.",
     "backgroundImage": "",
     "originalBackgroundImage": "assets/images/irish-countryside.jpg",
     "ambientSound": "",
-    "originalAmbientSound": "assets/audio/rural-helicopters.mp3", 
-    "connections": ["peace_line", "border_crossing"],
-    "npcs": ["safe_house_keeper", "fellow_volunteer", "farmer"],
+    "originalAmbientSound": "assets/audio/rural-helicopters.mp3",
+    "connections": [
+      "peace_line",
+      "border_crossing"
+    ],
+    "npcs": [
+      "safe_house_keeper",
+      "fellow_volunteer",
+      "farmer"
+    ],
     "searchable": true,
     "atmosphere": {
       "lighting": "dim candlelight",
@@ -94,13 +123,21 @@
   "local_pub": {
     "id": "local_pub",
     "name": "Local Pub",
-    "description": "A smoky, dimly lit atmosphere where whispers of recent events are traded over pints. Strangers are noted and carefully watched.",
+    "description": "Stale ale and old smoke cling to the low ceiling as murmured gossip passes between wary patrons. Strangers are judged in the time it takes to order a pint.",
     "backgroundImage": "",
     "originalBackgroundImage": "assets/images/irish-pub.jpg",
     "ambientSound": "",
     "originalAmbientSound": "assets/audio/pub-chatter.mp3",
-    "connections": ["falls_road", "shankill_road"],
-    "npcs": ["bartender", "local_drinker", "informant", "off_duty_soldier"],
+    "connections": [
+      "falls_road",
+      "shankill_road"
+    ],
+    "npcs": [
+      "bartender",
+      "local_drinker",
+      "informant",
+      "off_duty_soldier"
+    ],
     "searchable": false,
     "atmosphere": {
       "lighting": "warm amber glow",
@@ -116,21 +153,29 @@
   },
   "belfast_city_centre": {
     "id": "belfast_city_centre",
-    "name": "Belfast City Centre", 
-    "description": "Bomb-scarred shops and offices operate under the watchful eyes of security forces. The resilience of the people is palpable despite the constant threat.",
+    "name": "Belfast City Centre",
+    "description": "Glass crunches underfoot between boarded shops while sirens wail in the distance. Armored cars idle nearby, yet life presses on, brittle but unbroken.",
     "backgroundImage": "",
     "originalBackgroundImage": "assets/images/belfast-centre.jpg",
     "ambientSound": "",
     "originalAmbientSound": "assets/audio/urban-anxiety.mp3",
-    "connections": ["falls_road", "bombed_factory"],
-    "npcs": ["shopkeeper", "security_guard", "journalist", "police_officer"],
+    "connections": [
+      "falls_road",
+      "bombed_factory"
+    ],
+    "npcs": [
+      "shopkeeper",
+      "security_guard",
+      "journalist",
+      "police_officer"
+    ],
     "searchable": true,
     "atmosphere": {
       "lighting": "natural daylight filtered by dust",
       "weather": "intermittent rain",
       "mood": "determined normalcy"
     },
-    "environmentDetails": [  
+    "environmentDetails": [
       "Shoppers move quickly between stores, their eyes scanning for suspicious packages.",
       "Security barriers channel pedestrians through narrow checkpoints.",
       "Glass from last week's explosion still crunches underfoot in places.",
@@ -140,13 +185,20 @@
   "bombed_factory": {
     "id": "bombed_factory",
     "name": "Bombed Factory",
-    "description": "A skeleton of rubble and twisted metal from a recent blast. The acrid smell of destruction hangs heavy in the air.",
+    "description": "Charred beams claw at a gray sky, the stench of burnt chemicals clinging to your clothes as rescue workers sift through the wreckage.",
     "backgroundImage": "",
-    "originalBackgroundImage": "assets/images/bomb-damage.jpg", 
+    "originalBackgroundImage": "assets/images/bomb-damage.jpg",
     "ambientSound": "",
     "originalAmbientSound": "assets/audio/desolation.mp3",
-    "connections": ["belfast_city_centre", "military_checkpoint"],
-    "npcs": ["rescue_worker", "investigator", "survivor"],
+    "connections": [
+      "belfast_city_centre",
+      "military_checkpoint"
+    ],
+    "npcs": [
+      "rescue_worker",
+      "investigator",
+      "survivor"
+    ],
     "searchable": true,
     "atmosphere": {
       "lighting": "harsh emergency lighting",
@@ -163,17 +215,24 @@
   "military_checkpoint": {
     "id": "military_checkpoint",
     "name": "Military Checkpoint",
-    "description": "Armored vehicles and grim-faced soldiers block the road. Every car is stopped, every face scrutinized, every bag searched.",
+    "description": "Spotlights glare off armored plating as soldiers wave traffic through a gauntlet of sandbags. Radios crackle, and the line of cars grows restless.",
     "backgroundImage": "",
     "originalBackgroundImage": "assets/images/checkpoint.jpg",
     "ambientSound": "",
-    "originalAmbientSound": "assets/audio/military-checkpoint.mp3", 
-    "connections": ["bombed_factory", "border_crossing"],
-    "npcs": ["checkpoint_commander", "british_soldier", "ruc_officer"],
+    "originalAmbientSound": "assets/audio/military-checkpoint.mp3",
+    "connections": [
+      "bombed_factory",
+      "border_crossing"
+    ],
+    "npcs": [
+      "checkpoint_commander",
+      "british_soldier",
+      "ruc_officer"
+    ],
     "searchable": false,
     "atmosphere": {
       "lighting": "harsh spotlights",
-      "weather": "cold and exposed", 
+      "weather": "cold and exposed",
       "mood": "authoritarian control"
     },
     "environmentDetails": [
@@ -181,29 +240,44 @@
       "A sign warns that failure to stop will result in the use of lethal force.",
       "Soldiers with blackened faces peer through rifle scopes, fingers never far from triggers.",
       "The checkpoint is a reminder that in this place, freedom of movement is never guaranteed."
-    ]
+    ],
+    "perspectiveDescriptions": {
+      "catholic_teen": "Soldiers' eyes track your every move, suspicion heavy in the air.",
+      "protestant_civil": "The checkpoint feels like a necessary shield, and the soldiers nod politely."
+    }
   },
   "border_crossing": {
     "id": "border_crossing",
     "name": "Border Crossing",
-    "description": "A heavily fortified checkpoint marking the divide between north and south. Here, every crossing is a political act with potentially deadly consequences.",
+    "description": "Barriers funnel travelers into narrow lanes under suspicious eyes. A single wrong answer here can change the rest of your life.",
     "backgroundImage": "",
     "originalBackgroundImage": "assets/images/border-crossing.jpg",
     "ambientSound": "",
     "originalAmbientSound": "assets/audio/border-tension.mp3",
-    "connections": ["military_checkpoint", "countryside_safehouse"],
-    "npcs": ["border_guard", "customs_officer", "smuggler"],
+    "connections": [
+      "military_checkpoint",
+      "countryside_safehouse"
+    ],
+    "npcs": [
+      "border_guard",
+      "customs_officer",
+      "smuggler"
+    ],
     "searchable": false,
     "atmosphere": {
       "lighting": "institutional fluorescents",
       "weather": "neutral territory",
-      "mood": "bureaucratic menace" 
+      "mood": "bureaucratic menace"
     },
     "environmentDetails": [
       "The invisible line on the map becomes very real in the presence of armed guards.",
       "Documents are examined with the intensity of life-or-death decisions.",
       "On both sides of the border, similar accents speak with very different authorities.",
       "The crossing represents both escape and entrapment, depending on which direction you're traveling."
-    ]
+    ],
+    "perspectiveDescriptions": {
+      "ira_volunteer": "Every soldier here could recognize you; the border feels less like an exit and more like a trap.",
+      "foreign_reporter": "The guards treat you with forced politeness, wary of your questions."
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add unique knowledge traits to each character
- introduce item-gated and character-specific dialogue choices
- enrich locations with sensory descriptions and perspective variants
- expand violent, moral, and random events
- polish item descriptions and ending text

## Testing
- `npm test`
- `node validate_narrative.js`


------
https://chatgpt.com/codex/tasks/task_e_6850a2f2863c832fb364036eccef6c6d