### PR TITLE
Add glossary modal for historical terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ A comprehensive, immersive narrative game exploring the complex moral landscape 
 ### **Modern UI/UX**
 - **Glass Panel Design**: Beautiful, atmospheric interface with backdrop blur effects
 - **Animated Progress Bars**: Visual feedback for tension, morale, and PTSD levels
- - **Interactive Journal**: Persistent log of major choices with a new "fog of war" effect that mirrors the character's mental state
+- **Interactive Journal**: Persistent log of major choices with a new "fog of war" effect that mirrors the character's mental state
+- **In-game Glossary**: Quick reference for terms, factions, and key historical events
 - **Responsive Design**: Optimized for desktop and mobile devices
 
 ### **Visual & Audio Atmosphere**

--- a/data/glossary.json
+++ b/data/glossary.json
@@ -1,0 +1,14 @@
+{
+  "ira": {
+    "title": "Irish Republican Army (IRA)",
+    "description": "A republican paramilitary group seeking to end British rule in Northern Ireland."
+  },
+  "uda": {
+    "title": "Ulster Defence Association (UDA)",
+    "description": "A loyalist paramilitary organization defending unionist interests."
+  },
+  "bloody_sunday": {
+    "title": "Bloody Sunday (1972)",
+    "description": "British soldiers shot unarmed civil rights protesters in Derry, escalating tensions across Northern Ireland."
+  }
+}

--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
                         <button id="settings-btn" class="control-btn bg-gray-600 hover:bg-gray-700">
                             Settings
                         </button>
+                        <button id="glossary-btn" class="control-btn bg-gray-600 hover:bg-gray-700">
+                            Glossary
+                        </button>
                     </div>
                 </header>
 
@@ -174,6 +177,19 @@
             </div>
             <div class="flex justify-end space-x-2 mt-6">
                 <button id="close-settings" class="control-btn bg-gray-600 hover:bg-gray-700" data-i18n="close">
+                    Close
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Glossary Modal -->
+    <div id="glossary-modal" class="modal hidden" aria-hidden="true" tabindex="-1">
+        <div class="modal-content glass-panel p-6 max-w-2xl mx-auto mt-20" role="dialog" aria-modal="true" aria-labelledby="glossary-title">
+            <h2 id="glossary-title" class="text-2xl font-bold mb-4">Glossary</h2>
+            <div id="glossary-content" class="space-y-4 text-sm"></div>
+            <div class="flex justify-end mt-6">
+                <button id="close-glossary" class="control-btn bg-gray-600 hover:bg-gray-700" data-i18n="close">
                     Close
                 </button>
             </div>

--- a/js/modules/DataLoader.js
+++ b/js/modules/DataLoader.js
@@ -45,7 +45,8 @@ export class DataLoader {
                 dialogueTrees,
                 events,
                 items,
-                endings
+                endings,
+                glossary
             ] = await Promise.all([
                 this.loadJSON('story-graph.json'),
                 this.loadJSON('characters.json'),
@@ -53,7 +54,8 @@ export class DataLoader {
                 this.loadJSON('dialogue-trees.json'),
                 this.loadJSON('events.json'),
                 this.loadJSON('items.json'),
-                this.loadJSON('endings.json')
+                this.loadJSON('endings.json'),
+                this.loadOptionalJSON('glossary.json')
             ]);
 
             if (endings) {
@@ -70,7 +72,8 @@ export class DataLoader {
                 locations,
                 dialogueTrees,
                 events,
-                items
+                items,
+                glossary
             };
         } catch (error) {
             console.error('Failed to load game data:', error);

--- a/js/modules/GameEngine.js
+++ b/js/modules/GameEngine.js
@@ -17,6 +17,7 @@ export class GameEngine {
         this.saveManager = new SaveManager();
         this.eventManager = new EventManager(gameData.events);
         this.statsManager = new StatsManager();
+        this.glossary = gameData.glossary || {};
         
         // Game state
         this.currentPlayer = null;
@@ -94,9 +95,17 @@ export class GameEngine {
             this.uiRenderer.showSettings();
         });
 
+        document.getElementById('glossary-btn').addEventListener('click', () => {
+            this.uiRenderer.showGlossary(this.glossary);
+        });
+
         // Settings modal
         document.getElementById('close-settings').addEventListener('click', () => {
             this.uiRenderer.hideSettings();
+        });
+
+        document.getElementById('close-glossary').addEventListener('click', () => {
+            this.uiRenderer.hideGlossary();
         });
 
         // Volume controls

--- a/js/modules/UIRenderer.js
+++ b/js/modules/UIRenderer.js
@@ -59,7 +59,9 @@ export class UIRenderer {
             
             // Modals
             settingsModal: document.getElementById('settings-modal'),
-            endgameModal: document.getElementById('endgame-modal')
+            endgameModal: document.getElementById('endgame-modal'),
+            glossaryModal: document.getElementById('glossary-modal'),
+            glossaryContent: document.getElementById('glossary-content')
         };
     }
 
@@ -523,6 +525,43 @@ export class UIRenderer {
 
     hideSettings() {
         const modal = this.elements.settingsModal;
+        if (!modal) return;
+        modal.classList.add('hidden');
+        modal.setAttribute('aria-hidden', 'true');
+        if (modal.trapFocusHandler) {
+            modal.removeEventListener('keydown', modal.trapFocusHandler);
+            modal.trapFocusHandler = null;
+        }
+        if (this.modalOpener) {
+            this.modalOpener.focus();
+            this.modalOpener = null;
+        }
+    }
+
+    showGlossary(glossary = {}) {
+        const modal = this.elements.glossaryModal;
+        const content = this.elements.glossaryContent;
+        if (!modal || !content) return;
+
+        content.innerHTML = '';
+        Object.values(glossary).forEach(entry => {
+            const div = document.createElement('div');
+            div.innerHTML = `
+                <h3 class="font-semibold mb-1">${entry.title}</h3>
+                <p>${entry.description}</p>
+            `;
+            content.appendChild(div);
+        });
+
+        this.playUISound('assets/audio/menu-open.mp3');
+        const opener = document.activeElement;
+        modal.classList.remove('hidden');
+        modal.setAttribute('aria-hidden', 'false');
+        this.manageModalFocus(modal, opener);
+    }
+
+    hideGlossary() {
+        const modal = this.elements.glossaryModal;
         if (!modal) return;
         modal.classList.add('hidden');
         modal.setAttribute('aria-hidden', 'true');

--- a/locales/en.json
+++ b/locales/en.json
@@ -7,6 +7,7 @@
   "load_game": "Load Game",
   "restart": "Restart",
   "settings": "Settings",
+  "glossary": "Glossary",
   "close": "Close",
   "play_again": "Play Again",
   "view_journal": "View Journal",


### PR DESCRIPTION
## Summary
- load optional `glossary.json`
- display glossary modal via UI renderer
- wire up glossary button in game engine
- add translations and markup for glossary
- document the new feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850a5f8bc78832fab53c28ef97807ea