### PR TITLE
Add NPC relationship tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A comprehensive, immersive narrative game exploring the complex moral landscape 
 ### **Enhanced Dialogue & NPCs**
 - **Full Dialogue Trees**: Rich, branching conversations with multiple response options
 - **Faction Reputation System**: Dynamic relationships with IRA, UDA, British Army, and Civilians
+- **Personal Relationship System**: Individual NPCs track how much they like or dislike you
 - **Character-driven Interactions**: Each NPC has unique dialogue trees and story relevance
 
 ### **Violence & Consequences**

--- a/data/characters.json
+++ b/data/characters.json
@@ -16,6 +16,7 @@
       "british_army": -1,
       "civilians": 1
     },
+    "npcRelationships": {},
     "background": "Raised amid nightly patrols and whispered warnings, you've memorized every alley and escape route on the Falls Road. Friends have vanished without explanation, teaching you early that trust can be fatal.",
     "uniqueKnowledge": [
       "knows_back_alleys",
@@ -41,6 +42,7 @@
       "british_army": 1,
       "civilians": 0
     },
+    "npcRelationships": {},
     "background": "Working in the city council means navigating mountains of paperwork and political favors. You've seen how housing lists and permits can become weapons, and you know which forms go missing.",
     "uniqueKnowledge": [
       "bureaucratic_shortcuts",
@@ -67,6 +69,7 @@
       "british_army": 0,
       "civilians": 0
     },
+    "npcRelationships": {},
     "background": "Armed with a press pass and an outsider's eye, you're determined to capture the human stories behind the headlines. Everyone wants to bend your ear, yet no one fully trusts you.",
     "uniqueKnowledge": [
       "press_contacts",
@@ -93,6 +96,7 @@
       "british_army": -3,
       "civilians": -1
     },
+    "npcRelationships": {},
     "background": "You once shouted slogans with conviction, but months in hiding have worn you raw. Your network of safe houses is shrinking, and paranoia competes with devotion to the cause.",
     "uniqueKnowledge": [
       "code_phrases",

--- a/data/dialogue-trees.json
+++ b/data/dialogue-trees.json
@@ -426,6 +426,27 @@
             {
               "text": "Share a quiet toast",
               "nextNode": "simple_order",
+              "requirements": [],
+              "effects": {
+                "npcRelations": {
+                  "bartender": 1
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "informant": {
+      "name": "Shady Informant",
+      "description": "A figure lurking in the pub's shadows",
+      "dialogueTree": {
+        "initial": {
+          "text": "Keep your voice down. What do you want?",
+          "choices": [
+            {
+              "text": "Nothing right now.",
+              "nextNode": "polite_exit",
               "requirements": []
             }
           ]

--- a/data/events.json
+++ b/data/events.json
@@ -226,6 +226,10 @@
               "british_army": 3,
               "ira": -5,
               "uda": -3
+            },
+            "npcRelations": {
+              "informant": 2,
+              "ira_sympathizer": -2
             }
           },
           "consequence": "You cross a line that can never be uncrossed. The protection is real, but so is the price to your soul. You're safer, but you're also a traitor.",
@@ -239,6 +243,9 @@
             "factionReputation": {
               "ira": 2,
               "british_army": -3
+            },
+            "npcRelations": {
+              "informant": -2
             }
           },
           "consequence": "The informant pales and hurries away. You've maintained your integrity, but you've also made a dangerous enemy who knows your secrets.",
@@ -247,7 +254,10 @@
         {
           "text": "Listen but commit to nothing",
           "effects": {
-            "tension": 8
+            "tension": 8,
+            "npcRelations": {
+              "informant": -1
+            }
           },
           "consequence": "You nod noncommittally and excuse yourself. The informant watches you leave with calculating eyes. This conversation isn't over.",
           "nextNode": "location_hub"

--- a/index.html
+++ b/index.html
@@ -86,6 +86,12 @@
                                 <!-- Faction reputations will be rendered here -->
                             </ul>
                         </div>
+                        <div>
+                            <p class="mb-2"><strong data-i18n="npc_rel">NPC Relations:</strong></p>
+                            <ul id="npc-relations-list" class="text-sm space-y-1">
+                                <!-- NPC relationships will be rendered here -->
+                            </ul>
+                        </div>
                     </div>
                 </div>
 

--- a/js/modules/EventManager.js
+++ b/js/modules/EventManager.js
@@ -222,6 +222,14 @@ export class EventManager {
                         player.factionReputation[faction] = Math.max(-10, Math.min(10, player.factionReputation[faction]));
                     }
                 });
+            } else if (key === 'npcRelations') {
+                Object.keys(effects[key]).forEach(npc => {
+                    if (player.npcRelationships[npc] === undefined) {
+                        player.npcRelationships[npc] = 0;
+                    }
+                    player.npcRelationships[npc] += effects[key][npc];
+                    player.npcRelationships[npc] = Math.max(-10, Math.min(10, player.npcRelationships[npc]));
+                });
             } else if (player.stats[key] !== undefined) {
                 player.stats[key] += effects[key];
                 

--- a/js/modules/GameEngine.js
+++ b/js/modules/GameEngine.js
@@ -149,6 +149,7 @@ export class GameEngine {
             stats: { ...characterData.startingStats },
             inventory: [...characterData.startingInventory],
             factionReputation: { ...characterData.factionReputation },
+            npcRelationships: {},
             flags: {},
             dialogueHistory: [],
             journal: []
@@ -344,6 +345,10 @@ export class GameEngine {
             currentNode: 'initial'
         };
 
+        if (this.currentPlayer.npcRelationships[npcId] === undefined) {
+            this.currentPlayer.npcRelationships[npcId] = 0;
+        }
+
         this.gameStats.npcsMet.add(npcId);
         this.statsManager.meetNPC(npcId);
         this.addJournalEntry(`Spoke with ${npcData.name}`, 'interaction');
@@ -430,6 +435,14 @@ export class GameEngine {
                     if (this.currentPlayer.factionReputation[faction] !== undefined) {
                         this.currentPlayer.factionReputation[faction] += effects[key][faction];
                     }
+                });
+            } else if (key === 'npcRelations') {
+                Object.keys(effects[key]).forEach(npc => {
+                    if (this.currentPlayer.npcRelationships[npc] === undefined) {
+                        this.currentPlayer.npcRelationships[npc] = 0;
+                    }
+                    this.currentPlayer.npcRelationships[npc] += effects[key][npc];
+                    this.currentPlayer.npcRelationships[npc] = Math.max(-10, Math.min(10, this.currentPlayer.npcRelationships[npc]));
                 });
             } else if (this.currentPlayer.stats[key] !== undefined) {
                 this.currentPlayer.stats[key] += effects[key];

--- a/js/modules/StatsManager.js
+++ b/js/modules/StatsManager.js
@@ -27,6 +27,8 @@ export class StatsManager {
             // Faction relationships
             bestFactionRelationship: { faction: null, value: 0 },
             worstFactionRelationship: { faction: null, value: 0 },
+            bestNpcRelationship: { npc: null, value: 0 },
+            worstNpcRelationship: { npc: null, value: 0 },
             
             // Violence and moral choices
             violentEventsWitnessed: 0,
@@ -276,6 +278,27 @@ export class StatsManager {
                     this.sessionStats.worstFactionRelationship = {
                         faction,
                         value: reputation
+                    };
+                }
+            });
+        }
+
+        // Track NPC relationships
+        if (player.npcRelationships) {
+            Object.keys(player.npcRelationships).forEach(npc => {
+                const value = player.npcRelationships[npc];
+
+                if (value > this.sessionStats.bestNpcRelationship.value) {
+                    this.sessionStats.bestNpcRelationship = {
+                        npc,
+                        value
+                    };
+                }
+
+                if (value < this.sessionStats.worstNpcRelationship.value) {
+                    this.sessionStats.worstNpcRelationship = {
+                        npc,
+                        value
                     };
                 }
             });

--- a/js/modules/UIRenderer.js
+++ b/js/modules/UIRenderer.js
@@ -33,6 +33,7 @@ export class UIRenderer {
             ptsdLevel: document.getElementById('ptsd-level'),
             ptsdBar: document.getElementById('ptsd-bar'),
             factionList: document.getElementById('faction-list'),
+            npcRelationsList: document.getElementById('npc-relations-list'),
             
             // Inventory
             inventoryList: document.getElementById('inventory-list'),
@@ -386,6 +387,9 @@ export class UIRenderer {
         // Update faction reputation
         this.updateFactionReputation(player.factionReputation);
 
+        // Update NPC relationships
+        this.updateNpcRelationships(player.npcRelationships);
+
         // Update inventory
         this.updateInventory(player.inventory);
 
@@ -433,6 +437,24 @@ export class UIRenderer {
     getReputationPercentage(reputation) {
         // Convert reputation range (-10 to 10) to percentage (0 to 100)
         return Math.max(0, Math.min(100, ((reputation + 10) / 20) * 100));
+    }
+
+    updateNpcRelationships(npcRel) {
+        if (!npcRel || !this.elements.npcRelationsList) return;
+
+        this.elements.npcRelationsList.innerHTML = '';
+
+        Object.keys(npcRel).forEach(npc => {
+            const value = npcRel[npc];
+            const li = document.createElement('li');
+            li.innerHTML = `
+                <span>${npc.replace(/_/g, ' ')}</span>
+                <div class="faction-meter">
+                    <div class="faction-fill" style="width: ${this.getReputationPercentage(value)}%"></div>
+                </div>
+            `;
+            this.elements.npcRelationsList.appendChild(li);
+        });
     }
 
     updateInventory(inventory) {
@@ -668,7 +690,7 @@ export class UIRenderer {
             <ul class="list-disc list-inside space-y-2 text-sm">
                 <li>Make choices by clicking on the available options</li>
                 <li>Monitor your tension, morale, and PTSD levels</li>
-                <li>Keep track of your relationships with different factions</li>
+                <li>Keep track of your relationships with factions and individuals</li>
                 <li>Use items from your inventory when appropriate</li>
                 <li>Your choices have consequences - choose wisely</li>
             </ul>

--- a/js/modules/i18n.js
+++ b/js/modules/i18n.js
@@ -70,6 +70,7 @@ class I18n {
             "morale": "Morale",
             "ptsd": "PTSD",
             "faction_rep": "Faction Relations",
+            "npc_rel": "NPC Relations",
             "inventory": "Inventory",
             "actions": "Actions",
             "empty": "(empty)",
@@ -124,6 +125,7 @@ class I18n {
             "british_soldier": "British Soldier",
             "uda_member": "UDA Member",
             "bartender": "Pub Owner",
+            "informant": "Informant",
             "journalist": "Journalist",
             "police_officer": "Police Officer",
             

--- a/locales/en.json
+++ b/locales/en.json
@@ -16,6 +16,7 @@
   "morale": "Morale",
   "ptsd": "PTSD",
   "faction_rep": "Faction Relations",
+  "npc_rel": "NPC Relations",
   "inventory": "Inventory",
   "actions": "Actions",
   "empty": "(empty)",
@@ -59,6 +60,7 @@
   "british_soldier": "British Soldier",
   "uda_member": "UDA Member",
   "bartender": "Pub Owner",
+  "informant": "Informant",
   "journalist": "Journalist",
   "police_officer": "Police Officer",
   


### PR DESCRIPTION
## Summary
- track NPC relationships in game data
- add Informant NPC and bartender friendship option
- update events to modify NPC relations
- extend UI and translations for personal relationships
- record best/worst NPC relations in stats

## Testing
- `node validate_narrative.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850a60e2a08832fae7c71309f768b32