### PR TITLE
Fix character selection to advance story

### DIFF
--- a/js/modules/GameEngine.js
+++ b/js/modules/GameEngine.js
@@ -200,6 +200,9 @@ export class GameEngine {
         if (this.state === 'menu') {
             if (choice.characterId) {
                 this.startGame(choice.characterId);
+                if (choice.nextNode) {
+                    await this.processStoryNode(choice.nextNode);
+                }
                 return;
             }
 


### PR DESCRIPTION
## Summary
- when starting the game after character selection, also process the `game_start` node so that play continues

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850ab6c5c3c832f9a45a6aa2daacea1