### PR TITLE
Improve UI layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,10 @@
 </head>
 <body class="p-4 md:p-8">
     <div class="vignette"></div>
-    <div class="max-w-7xl mx-auto grid grid-cols-1 xl:grid-cols-4 gap-6">
+    <div class="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-3 gap-6">
         
         <!-- Main Content Column -->
-        <div class="xl:col-span-3 grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <div class="lg:col-span-2">
+        <div class="lg:col-span-2 space-y-6">
                 <header class="mb-6">
                     <h1 class="text-4xl font-bold mb-2 text-gray-100 border-b-2 border-yellow-400 pb-2">
                         Troubles Simulator
@@ -40,6 +39,7 @@
 
                 <main id="game-area" class="relative">
                     <div id="background-image" class="absolute inset-0 opacity-30 bg-cover bg-center transition-all duration-1000"></div>
+                    <div id="location-display" class="relative z-10 mb-4"></div>
                     <div id="output" class="relative z-10 h-[60vh] lg:h-[75vh] overflow-y-auto p-6 rounded-lg shadow-inner text-lg leading-relaxed glass-panel">
                         <!-- Game text will be rendered here -->
                     </div>
@@ -59,8 +59,8 @@
                 </main>
             </div>
 
-            <!-- Stats Column -->
-            <div class="space-y-6">
+            <!-- Sidebar -->
+            <div id="sidebar" class="space-y-6 lg:col-span-1">
                 <!-- Status Panel -->
                 <div id="stats-panel" class="glass-panel p-4">
                     <h2 class="text-xl font-bold mb-3 border-b border-gray-600 pb-2" data-i18n="status">Status</h2>
@@ -113,11 +113,8 @@
                         <!-- Action buttons will be rendered here -->
                     </div>
                 </div>
-            </div>
-        </div>
 
-        <!-- Journal Sidebar -->
-        <div id="journal-sidebar" class="space-y-6">
+        <!-- Journal and Info (Sidebar continuation) -->
             <div class="glass-panel p-4">
                 <h2 class="text-xl font-bold mb-3 border-b border-gray-600 pb-2" data-i18n="journal">Journal</h2>
                 <div id="journal-content" class="max-h-96 overflow-y-auto space-y-3">

--- a/js/modules/UIRenderer.js
+++ b/js/modules/UIRenderer.js
@@ -57,6 +57,7 @@ export class UIRenderer {
             
             // Background
             backgroundImage: document.getElementById('background-image'),
+            locationDisplay: document.getElementById('location-display'),
             
             // Modals
             settingsModal: document.getElementById('settings-modal'),
@@ -225,20 +226,25 @@ export class UIRenderer {
             this.setBackgroundImage(location.backgroundImage);
         }
 
-        // Render location description
+        // Clear main output
+        if (this.elements.output) {
+            this.elements.output.innerHTML = '';
+        }
+
+        // Render location description to dedicated display
         const locationHtml = `
-            <h2 class="text-3xl font-bold location-title mb-4">${location.name}</h2>
-            <p class="text-lg leading-relaxed mb-4">${location.description}</p>
+            <h2 class="text-3xl font-bold location-title mb-1">${location.name}</h2>
+            <p class="text-lg leading-relaxed">${location.description}</p>
         `;
 
-        this.renderText(locationHtml, this.elements.output);
+        this.renderText(locationHtml, this.elements.locationDisplay, { append: false });
 
         // Add environmental details
         if (location.environmentDetails && location.environmentDetails.length > 0) {
             const randomDetail = location.environmentDetails[
                 Math.floor(Math.random() * location.environmentDetails.length)
             ];
-            
+
             this.renderText(
                 `<p class="text-gray-300 italic mt-2">${randomDetail}</p>`,
                 this.elements.output,
@@ -791,6 +797,9 @@ export class UIRenderer {
         this.elements.characterName.textContent = '';
         this.elements.characterBackground.textContent = '';
         this.elements.currentLocation.textContent = '';
+        if (this.elements.locationDisplay) {
+            this.elements.locationDisplay.innerHTML = '';
+        }
         
         // Reset game stats
         this.elements.choicesCount.textContent = '0';

--- a/styles/main.css
+++ b/styles/main.css
@@ -65,6 +65,12 @@ body.accessibility-mode .glass-panel {
     color: var(--accent-color);
 }
 
+#location-display {
+    border-left: 4px solid var(--accent-color);
+    padding-left: 1rem;
+    margin-bottom: 1rem;
+}
+
 /* Buttons */
 .control-btn {
     padding: 8px 16px;
@@ -189,6 +195,13 @@ body.accessibility-mode .glass-panel {
     background: rgba(59, 130, 246, 0.1);
 }
 
+/* Journal entry type styles */
+.journal-entry.choice { border-left-color: #3b82f6; }
+.journal-entry.event { border-left-color: #ef4444; }
+.journal-entry.location { border-left-color: #a3e635; }
+.journal-entry.action { border-left-color: #f59e0b; }
+.journal-entry.discovery { border-left-color: #14b8a6; }
+
 /* Loading Animation */
 .loading-spinner {
     width: 40px;
@@ -231,11 +244,7 @@ body.accessibility-mode .glass-panel {
 
 /* Responsive Design */
 @media (max-width: 768px) {
-    .xl\:col-span-3 {
-        order: 1;
-    }
-    
-    #journal-sidebar {
+    #sidebar {
         order: 2;
     }
     


### PR DESCRIPTION
## Summary
- switch to two-column grid layout with a dedicated sidebar
- add persistent `location-display` area above the main output
- add journal entry highlighting and location styles
- update UIRenderer to render locations in the new area

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850abb235f0832f988967b05d45d49e