### PR TITLE
Fix intro rendering order

### DIFF
--- a/Troubles_Simulator_v2.html
+++ b/Troubles_Simulator_v2.html
@@ -258,6 +258,8 @@
 
             startCharacterCreation() {
                 this.state = "character_creation";
+                // Clear previous output so the introduction always appears first
+                this.output.innerHTML = "";
                 let characterHtml = `<p>${gameData.introText}</p><p class="mt-4 font-bold">Choose your background:</p><ul>`;
                 for (const key in gameData.characters) {
                     characterHtml += `<li class="mt-2"><span class="command-text">[${key}]</span>: ${gameData.characters[key].description}</li>`;


### PR DESCRIPTION
## Summary
- ensure text output is cleared before displaying the intro

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850b19c2060832f87e35d11700d957e