### PR TITLE
Fix dialogue handling and custom element error

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,16 @@ import { GameEngine } from './modules/GameEngine.js';
 import { DataLoader } from './modules/DataLoader.js';
 import { i18n } from './modules/i18n.js';
 
+// Prevent errors if a custom element is registered multiple times
+if (window.customElements && window.customElements.define) {
+    const originalDefine = window.customElements.define;
+    window.customElements.define = function(name, ctor, options) {
+        if (!window.customElements.get(name)) {
+            originalDefine.call(this, name, ctor, options);
+        }
+    };
+}
+
 const PRELOAD_ASSETS = false; // Set to true when assets are available
 class TroublesSimulator {
     constructor() {

--- a/js/modules/GameEngine.js
+++ b/js/modules/GameEngine.js
@@ -218,7 +218,28 @@ export class GameEngine {
         // Increment choice counter
         this.gameStats.choicesMade++;
 
-        if (context === 'event') {
+        if (context === 'dialogue' && this.activeDialogue) {
+            // Apply any effects tied to the dialogue choice
+            if (choice.effects) {
+                this.applyEffects(choice.effects);
+            }
+
+            const npcDialogue = this.activeDialogue.npcData.dialogueTree;
+            if (choice.nextNode && npcDialogue[choice.nextNode]) {
+                this.activeDialogue.currentNode = choice.nextNode;
+                this.uiRenderer.renderDialogue(this.activeDialogue);
+            } else {
+                // End dialogue if no valid next node
+                this.activeDialogue = null;
+                this.renderLocationHub();
+            }
+
+            this.uiRenderer.updatePlayerStats(this.currentPlayer);
+            this.uiRenderer.updateGameStats(this.gameStats);
+            this.checkGameState();
+            this.checkForRandomEvents();
+            return;
+        } else if (context === 'event') {
             this.statsManager.recordChoice(choice);
 
             const result = this.eventManager.processEventChoice(choice, this.currentPlayer);


### PR DESCRIPTION
## Summary
- avoid redefining already-registered custom elements
- correctly progress dialogue choices in GameEngine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850bf4be2f8832fb748bd5131619f3e