### PR TITLE
Add debug logging

### DIFF
--- a/js/modules/DataLoader.js
+++ b/js/modules/DataLoader.js
@@ -29,6 +29,7 @@ export class DataLoader {
             
             const data = await response.json();
             this.cache.set(filename, data);
+            console.debug(`Loaded ${filename}`, data);
             return data;
         } catch (error) {
             console.error(`Error loading ${filename}:`, error);
@@ -57,6 +58,17 @@ export class DataLoader {
                 this.loadJSON('endings.json'),
                 this.loadOptionalJSON('glossary.json')
             ]);
+
+            console.debug('All data loaded', {
+                storyGraph,
+                characters,
+                locations,
+                dialogueTrees,
+                events,
+                items,
+                endings,
+                glossary
+            });
 
             if (endings) {
                 if (endings.nodes) {

--- a/js/modules/EventManager.js
+++ b/js/modules/EventManager.js
@@ -186,6 +186,7 @@ export class EventManager {
 
     // Process event choice
     processEventChoice(choice, player) {
+        console.debug('Processing event choice', choice);
         if (!this.activeEvent) {
             console.warn('No active event to process choice for');
             return null;
@@ -206,7 +207,7 @@ export class EventManager {
         
         // Clear active event
         this.activeEvent = null;
-        
+        console.debug('Event choice result', result);
         return result;
     }
 

--- a/js/modules/GameEngine.js
+++ b/js/modules/GameEngine.js
@@ -166,6 +166,7 @@ export class GameEngine {
 
         // Initialize location
         this.currentLocation = this.gameData.locations[this.currentPlayer.location];
+        console.debug('Current location set', this.currentLocation);
         
         // Set up initial state
         this.state = 'playing';
@@ -178,6 +179,8 @@ export class GameEngine {
         
         // Start background music
         this.audioManager.playAmbientSound(this.currentLocation.ambientSound);
+
+        console.debug('Player initialized', this.currentPlayer);
         
         // Render initial location
         this.uiRenderer.renderLocation(this.currentLocation, this.currentPlayer);
@@ -191,7 +194,7 @@ export class GameEngine {
     }
 
     async onChoiceSelected(detail) {
-        console.log('Choice selected:', detail);
+        console.debug('Choice selected', detail);
 
         const choice = detail.choice || detail;
         const context = detail.context || 'story';
@@ -281,6 +284,7 @@ export class GameEngine {
     }
 
     async processStoryNode(nodeId) {
+        console.debug('Processing story node', nodeId);
         const node = this.gameData.storyGraph.nodes[nodeId];
         if (!node) {
             console.error(`Story node ${nodeId} not found`);
@@ -306,6 +310,7 @@ export class GameEngine {
     }
 
     async processAction(action, target) {
+        console.debug('Processing action', action, target);
         switch (action) {
             case 'move':
                 await this.moveToLocation(target);
@@ -328,6 +333,7 @@ export class GameEngine {
     }
 
     async moveToLocation(locationId) {
+        console.debug('Moving to location', locationId);
         const location = this.gameData.locations[locationId];
         if (!location) {
             console.error(`Location ${locationId} not found`);
@@ -366,6 +372,7 @@ export class GameEngine {
     }
 
     async startDialogue(npcId) {
+        console.debug('Starting dialogue with', npcId);
         const npcData = this.gameData.dialogueTrees.npcs[npcId];
         if (!npcData) {
             console.error(`NPC ${npcId} not found`);
@@ -390,6 +397,7 @@ export class GameEngine {
     }
 
     async searchLocation() {
+        console.debug('Searching current location');
         const location = this.currentLocation;
         if (!location.searchable) {
             this.uiRenderer.showNotification('There is nothing to search here.', 'info');
@@ -425,6 +433,7 @@ export class GameEngine {
     }
 
     async useItem(itemId) {
+        console.debug('Using item', itemId);
         if (!this.currentPlayer.inventory.includes(itemId)) {
             this.uiRenderer.showNotification('You do not have that item.', 'warning');
             return;
@@ -459,6 +468,7 @@ export class GameEngine {
     }
 
     applyEffects(effects) {
+        console.debug('Applying effects', effects);
         if (!effects) return;
 
         // Apply stat changes
@@ -519,6 +529,7 @@ export class GameEngine {
     }
 
     checkForRandomEvents() {
+        console.debug('Checking for random events');
         if (this.eventManager.activeEvent) return;
 
         if (Math.random() < 0.3) { // 30% chance
@@ -536,6 +547,7 @@ export class GameEngine {
     }
 
     triggerEvent(eventData) {
+        console.debug('Triggering event through game engine', eventData.id);
         const event = this.eventManager.triggerEvent(
             eventData,
             this.currentPlayer,

--- a/js/modules/StatsManager.js
+++ b/js/modules/StatsManager.js
@@ -186,6 +186,7 @@ export class StatsManager {
 
     // Choice tracking
     recordChoice(choice, responseTime = 0) {
+        console.debug('Recording choice', choice);
         this.sessionStats.choicesMade++;
         
         if (responseTime > 0) {
@@ -270,6 +271,7 @@ export class StatsManager {
 
     // Stats updates
     updatePlayerStats(player) {
+        console.debug('Updating player stats', player.stats);
         if (!player || !player.stats) return;
         
         // Track maximum values reached


### PR DESCRIPTION
## Summary
- insert debug statements while loading game data
- log important game actions like choices and location changes
- trace event processing in EventManager
- report stats updates

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850c12d7ee4832f98d5eb5e19c68837