### PR TITLE
Fix missing action menu after moving

### DIFF
--- a/js/modules/GameEngine.js
+++ b/js/modules/GameEngine.js
@@ -361,10 +361,10 @@ export class GameEngine {
         
         // Change ambient sound
         this.audioManager.playAmbientSound(location.ambientSound);
-        
-        // Render new location
-        this.uiRenderer.renderLocation(location, this.currentPlayer);
-        
+
+        // Render location hub (location + available actions)
+        this.renderLocationHub();
+
         // Trigger location changed event
         document.dispatchEvent(new CustomEvent('locationChanged', {
             detail: { locationId, location }


### PR DESCRIPTION
## Summary
- after moving to a new location, show available actions again

## Testing
- `node validate_narrative.js`

------
https://chatgpt.com/codex/tasks/task_e_6850d0b4a77c832fb73ab63773d93580