### PR TITLE
Expand informant dialogue

### DIFF
--- a/data/dialogue-trees.json
+++ b/data/dialogue-trees.json
@@ -448,6 +448,139 @@
               "text": "Nothing right now.",
               "nextNode": "polite_exit",
               "requirements": []
+            },
+            {
+              "text": "I'm looking for information.",
+              "nextNode": "ask_info",
+              "requirements": []
+            },
+            {
+              "text": "We talked before.",
+              "nextNode": "follow_up",
+              "requirements": [
+                {
+                  "type": "flag",
+                  "key": "met_informant",
+                  "value": true
+                }
+              ]
+            }
+          ]
+        },
+        "ask_info": {
+          "text": "Depends on who you represent.",
+          "choices": [
+            {
+              "text": "You know I'm sympathetic to the IRA.",
+              "nextNode": "ira_info",
+              "requirements": [
+                {
+                  "type": "reputation",
+                  "key": "ira",
+                  "operator": ">=",
+                  "value": 1
+                }
+              ],
+              "effects": {
+                "setFlags": { "met_informant": true },
+                "npcRelations": { "informant": 1 }
+              }
+            },
+            {
+              "text": "Tell me about the UDA.",
+              "nextNode": "uda_info",
+              "requirements": [
+                {
+                  "type": "reputation",
+                  "key": "uda",
+                  "operator": ">=",
+                  "value": 1
+                }
+              ],
+              "effects": {
+                "setFlags": { "met_informant": true },
+                "npcRelations": { "informant": 1 }
+              }
+            },
+            {
+              "text": "I'm neutral, just looking for gossip.",
+              "nextNode": "generic_rumor",
+              "requirements": [],
+              "effects": {
+                "setFlags": { "met_informant": true }
+              }
+            }
+          ]
+        },
+        "ira_info": {
+          "text": "Word is the IRA is planning something big near the docks.",
+          "choices": [
+            {
+              "text": "Thanks for the tip.",
+              "nextNode": "polite_exit",
+              "requirements": [],
+              "effects": {
+                "npcRelations": { "informant": 1 }
+              }
+            }
+          ]
+        },
+        "uda_info": {
+          "text": "UDA lads are stockpiling weapons outside town.",
+          "choices": [
+            {
+              "text": "Good to know.",
+              "nextNode": "polite_exit",
+              "requirements": [],
+              "effects": {
+                "npcRelations": { "informant": 1 }
+              }
+            }
+          ]
+        },
+        "generic_rumor": {
+          "text": "There's talk of increased patrols and informers everywhere.",
+          "choices": [
+            {
+              "text": "Anything else?",
+              "nextNode": "more_generic",
+              "requirements": []
+            },
+            {
+              "text": "That's enough for now.",
+              "nextNode": "polite_exit",
+              "requirements": []
+            }
+          ],
+          "effects": {
+            "tension": 1
+          }
+        },
+        "more_generic": {
+          "text": "Keep your head down and trust no one.",
+          "choices": [
+            {
+              "text": "Understood.",
+              "nextNode": "polite_exit",
+              "requirements": []
+            }
+          ]
+        },
+        "follow_up": {
+          "text": "Oh, it's you again. Changed your mind?",
+          "choices": [
+            {
+              "text": "Got any new information?",
+              "nextNode": "ask_info",
+              "requirements": []
+            },
+            {
+              "text": "Just checking in.",
+              "nextNode": "polite_exit",
+              "requirements": [],
+              "effects": {
+                "npcRelations": { "informant": 1 }
+              }
             }
           ]
         }

--- a/js/modules/GameEngine.js
+++ b/js/modules/GameEngine.js
@@ -488,6 +488,10 @@ export class GameEngine {
                     this.currentPlayer.npcRelationships[npc] += effects[key][npc];
                     this.currentPlayer.npcRelationships[npc] = Math.max(-10, Math.min(10, this.currentPlayer.npcRelationships[npc]));
                 });
+            } else if (key === 'setFlags') {
+                Object.keys(effects[key]).forEach(flag => {
+                    this.currentPlayer.flags[flag] = effects[key][flag];
+                });
             } else if (this.currentPlayer.stats[key] !== undefined) {
                 this.currentPlayer.stats[key] += effects[key];
                 


### PR DESCRIPTION
## Summary
- extend Shady Informant tree with new branches
- allow dialogue choices to set story flags

## Testing
- `node validate_narrative.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850eeaf510c832faf30292bdcacce42